### PR TITLE
Added STORE_UUID ARG and removed stub_status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM debian:stretch-slim
 
 LABEL maintainer="NGINX Controller Engineering"
 
-ARG cert=nginx-repo.crt
-ARG key=nginx-repo.key
-
 # e.g '1234567890'
 ARG API_KEY 
 ENV ENV_API_KEY=$API_KEY
@@ -13,18 +10,16 @@ ENV ENV_API_KEY=$API_KEY
 ARG CONTROLLER_URL
 ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 
+# e.g True or False
+ARG STORE_UUID=False
+ENV ENV_STORE_UUID=$STORE_UUID
 
-
-# Download certificate and key from the customer portal (https://cs.nginx.com)
+# Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
-RUN mkdir -p /etc/nginx/sites-enabled/ 
-COPY $cert /etc/ssl/nginx/
-COPY $key /etc/ssl/nginx/
-COPY stub_status.conf /etc/nginx/sites-enabled/ 
+COPY nginx-repo.* /etc/ssl/nginx/
 COPY nginx-plus-api.conf /etc/nginx/conf.d/
 COPY ./entrypoint.sh /
 
-# Install NGINX Plus
 # Install NGINX Plus
 RUN set -ex \
   && apt-get update && apt-get upgrade -y \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For more information, please refer to our [Controller Dockerfile repository](htt
 
 By default the agent will try to determine the OS `hostname` on startup. The `hostname` is used to generate a UUID to uniquely identify the NGINX instance in NGINX Controller.  When the Agent is run inside of a container the hostname is the shortened Docker Container ID on the host where the container is running.
 
-If the `hostname` is set, it is also advisable to set `store_uuid=true`  This additional setting will persist the defined `hostname` and a dynamically generated uuid identifier together.  This additional setting allows the container instance to be stopped and started or persist if the container host is rebooted.
+If the `hostname` is set, it is also advisable to set `STORE_UUID=True`  This additional setting will persist the defined `hostname` and a dynamically generated uuid identifier together.  This additional setting allows the container instance to be stopped and started or persist if the container host is rebooted.
 
 This means that each new container started from a Controller-enabled Docker image will be reported as a standalone system in the Controller Console.
 This is the recommended configuration, as Controller will aggregate metrics across your instances based on the application, application component, location, environment, and so on.

--- a/stub_status.conf
+++ b/stub_status.conf
@@ -1,9 +1,0 @@
-server {
-    listen 127.0.0.1:80;
-    server_name 127.0.0.1;
-    location /nginx_status {
-        stub_status on;
-        allow 127.0.0.1;
-        deny all;
-    }
-} 


### PR DESCRIPTION
STORE_UUID can now be set as a build arg
Removed stub_status (does not apply to NGINX Plus)
Combined both nginx-repo.* files into a single COPY
Updated README with correct case for STORE_UUID (True/False is case sensitive)