### PR TITLE
Set instance location with ENV_LOCATION. NJS module now installed for APIM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 ARG STORE_UUID=False
 ENV ENV_STORE_UUID=$STORE_UUID
 
+# e.g Instance location already defined in Controller
+ARG LOCATION
+ENV ENV_LOCATION=$LOCATION
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -44,7 +48,8 @@ RUN set -ex \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
   && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
-  && apt-get update && apt-get install -y nginx-plus  \
+  # NGINX Javascript module needed for APIM
+  && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs  \
   && rm -rf /var/lib/apt/lists/* \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL}/install/controller/ > install.sh \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ nginx_status_conf="/etc/nginx/conf.d/stub_status.conf"
 api_key=""
 controller_hostname=""
 controller_url=""
+location=""
 
 # Launch nginx
 echo "starting nginx ..."
@@ -34,7 +35,10 @@ test -z "${controller_hostname}" && \
 test -n "${ENV_CONTROLLER_URL}" && \
     controller_url=${ENV_CONTROLLER_URL}
 
-if [ -n "${api_key}" -o -n "${controller_hostname}" -o -n "${controller_url}" ]; then
+test -n "${ENV_LOCATION}" && \
+    location=${ENV_LOCATION}
+
+if [ -n "${api_key}" -o -n "${controller_hostname}" -o -n "${controller_url}" -o -n "${location}" ]; then
     echo "updating ${agent_conf_file} ..."
 
     if [ ! -f "${agent_conf_file}" ]; then
@@ -56,6 +60,11 @@ if [ -n "${api_key}" -o -n "${controller_hostname}" -o -n "${controller_url}" ];
     test -n "${controller_url}" && \
     echo " ---> using controller = ${controller_url}" && \
     sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
+	${agent_conf_file}"
+
+    test -n "${location}" && \
+    echo " ---> using location = ${location}" && \
+    sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \
 	${agent_conf_file}"
 
     test -f "${agent_conf_file}" && \


### PR DESCRIPTION
You can now specify instance location by setting the ENV_LOCATION environment variable in `docker run` or passing the LOCATION build-arg to `docker build`.  The location must already exist in the Controller.

The APIM feature of Controller 3.6 requires the _njs_ module so `nginx-plus-module-njs` is now installed in the Dockerfile.
