### PR TITLE
instance name defaults to hostname output

### DIFF
--- a/amazon/entrypoint.sh
+++ b/amazon/entrypoint.sh
@@ -11,7 +11,7 @@ agent_conf_file="/etc/controller-agent/agent.conf"
 agent_log_file="/var/log/nginx-controller/agent.log"
 nginx_status_conf="/etc/nginx/conf.d/stub_status.conf"
 api_key=""
-instance_name=""
+instance_name="$(hostname -f)"
 controller_url=""
 location=""
 

--- a/centos/entrypoint.sh
+++ b/centos/entrypoint.sh
@@ -11,7 +11,7 @@ agent_conf_file="/etc/controller-agent/agent.conf"
 agent_log_file="/var/log/nginx-controller/agent.log"
 nginx_status_conf="/etc/nginx/conf.d/stub_status.conf"
 api_key=""
-instance_name=""
+instance_name="$(hostname -f)"
 controller_url=""
 location=""
 

--- a/debian/entrypoint.sh
+++ b/debian/entrypoint.sh
@@ -12,7 +12,7 @@ agent_conf_file="/etc/controller-agent/agent.conf"
 agent_log_file="/var/log/nginx-controller/agent.log"
 nginx_status_conf="/etc/nginx/conf.d/stub_status.conf"
 api_key=""
-instance_name=""
+instance_name="$(hostname -f)"
 controller_url=""
 location=""
 

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -12,7 +12,7 @@ agent_conf_file="/etc/controller-agent/agent.conf"
 agent_log_file="/var/log/nginx-controller/agent.log"
 nginx_status_conf="/etc/nginx/conf.d/stub_status.conf"
 api_key=""
-instance_name=""
+instance_name="$(hostname -f)"
 controller_url=""
 location=""
 


### PR DESCRIPTION
* `instance_name` defaults to the result of `hostname -f` in entrypoint