### PR TITLE
IND-19421|Switch between endpoints to fetch the agent script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ ENV HOSTNAME my-docker-instance-123
 
 Alternatively, environment settings can be passed at the container launch time. Use the `-e` option with `docker run`, for example:
 
-    ```bash
-    docker run --name mynginx1 -e ENV_CONTROLLER_API_KEY=1234567890 -e ENV_CONTROLLER_INSTANCE_NAME=my-instance-123 -d nginx-agent
-    ```
+```bash
+docker run --name mynginx1 -e ENV_CONTROLLER_API_KEY=1234567890 -e ENV_CONTROLLER_INSTANCE_NAME=my-instance-123 -d nginx-agent
+```
 
 ### 1.3. Current Limitations
 
@@ -90,7 +90,11 @@ Copy your NGINX Plus repository certificate and key to the cloned folder.
 Edit the Dockerfile with your API_KEY and ENV_CONTROLLER_URL
 
 ```bash
-docker build --build-arg CONTROLLER_URL=https://<fqdn>:8443/1.4 --build-arg API_KEY='abcdefxxxxxx' -t nginx-agent .
+# If NGINX Controller version is 3.10 or older
+docker build --build-arg CONTROLLER_URL=https://<fqdn>:8443/1.4/install/controller/ --build-arg API_KEY='abcdefxxxxxx' -t nginx-agent .
+
+# If NGINX Controller version is 3.11 or newer
+docker build --build-arg CONTROLLER_URL=https://<fqdn>/install/controller-agent --build-arg API_KEY='abcdefxxxxxx' -t nginx-agent .
 ```
 
 After the image is built, check the list of Docker images:
@@ -107,7 +111,11 @@ nginx-agent       latest              d039b39d2987        3 minutes ago       24
 Alternately, you can set the VAR STORE_UUID=True during the image build process. This has the effect of persisting the instance displayName in NGINX Controller through container stop and start actions. The displayName will default to the hostname of the machine.
 
 ```bash
-sudo docker build --build-arg CONTROLLER_URL=https://<DNS>:8443/1.4 --build-arg API_KEY='abcdefxxxxxx' --build-arg STORE_UUID=True -t nginx-agent .
+# If NGINX Controller version is 3.10 or older
+sudo docker build --build-arg CONTROLLER_URL=https://<fqdn>:8443/1.4/install/controller/ --build-arg API_KEY='abcdefxxxxxx' --build-arg STORE_UUID=True -t nginx-agent .
+
+# If NGINX Controller version is 3.11 or newer
+sudo docker build --build-arg CONTROLLER_URL=https://<fqdn>/install/controller-agent --build-arg API_KEY='abcdefxxxxxx' --build-arg STORE_UUID=True -t nginx-agent .
 ```
 
 ### 2.2. Running an NGINX Controller-enabled NGINX Docker Container

--- a/amazon/Dockerfile
+++ b/amazon/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="NGINX Controller Engineering"
 ARG API_KEY
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 
-# e.g https://<fqdn>:8443/1.4
+# e.g https://<fqdn>/install/controller-agent
 ARG CONTROLLER_URL
 ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 
@@ -55,7 +55,7 @@ RUN set -ex \
   # NGINX Javascript module needed for APIM
   && yum update && yum -y install nginx-plus nginx-plus-module-njs  \
   # Install Controller Agent
-  && curl -k -sS -L ${CONTROLLER_URL}/install/controller/ > install.sh \
+  && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   # TODO: remove once launching agent using `service` has been handled in the install script
   && sed -i '/^# Unconditionally stop the agent service/,$d' install.sh \

--- a/amazon/entrypoint.sh
+++ b/amazon/entrypoint.sh
@@ -64,11 +64,6 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_url}" -o -n "$
     sh -c "sed -i.old -e 's/instance_name.*$/instance_name = $instance_name/' \
 	${agent_conf_file}"
 
-    test -n "${controller_url}" && \
-    echo " ---> using controller = ${controller_url}" && \
-    sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
-	${agent_conf_file}"
-
     test -n "${location}" && \
     echo " ---> using location = ${location}" && \
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="NGINX Controller Engineering"
 ARG API_KEY 
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 
-# e.g https://<fqdn>:8443/1.4
+# e.g https://<fqdn>/install/controller-agent
 ARG CONTROLLER_URL
 ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 
@@ -44,7 +44,7 @@ RUN set -ex \
   # NGINX Javascript module needed for APIM
   && yum update && yum -y install nginx-plus nginx-plus-module-njs  \
   # Install Controller Agent
-  && curl -k -sS -L ${CONTROLLER_URL}/install/controller/ > install.sh \
+  && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   # TODO: remove once launching agent using `service` has been handled in the install script
   && sed -i '/^# Unconditionally stop the agent service/,$d' install.sh \

--- a/centos/entrypoint.sh
+++ b/centos/entrypoint.sh
@@ -64,11 +64,6 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_url}" -o -n "$
     sh -c "sed -i.old -e 's/instance_name.*$/instance_name = $instance_name/' \
 	${agent_conf_file}"
 
-    test -n "${controller_url}" && \
-    echo " ---> using controller = ${controller_url}" && \
-    sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
-	${agent_conf_file}"
-
     test -n "${location}" && \
     echo " ---> using location = ${location}" && \
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="NGINX Controller Engineering"
 ARG API_KEY 
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 
-# e.g https://<fqdn>:8443/1.4
+# e.g https://<fqdn>/install/controller-agent
 ARG CONTROLLER_URL
 ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 
@@ -51,7 +51,7 @@ RUN set -ex \
   && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs  \
   && rm -rf /var/lib/apt/lists/* \
   # Install Controller Agent
-  && curl -k -sS -L ${CONTROLLER_URL}/install/controller/ > install.sh \
+  && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data

--- a/debian/entrypoint.sh
+++ b/debian/entrypoint.sh
@@ -65,11 +65,6 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_url}" -o -n "$
     sh -c "sed -i.old -e 's/instance_name.*$/instance_name = $instance_name/' \
 	${agent_conf_file}"
 
-    test -n "${controller_url}" && \
-    echo " ---> using controller = ${controller_url}" && \
-    sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
-	${agent_conf_file}"
-
     test -n "${location}" && \
     echo " ---> using location = ${location}" && \
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \

--- a/debian/examples/agent-layer/Dockerfile
+++ b/debian/examples/agent-layer/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /controller
 # Example solution for multiple service management in docker image could be found in official docker
 # documentation:
 # https://docs.docker.com/config/containers/multi-service_container
-RUN printf "curl -skSL https://\$CTRL_HOST:8443/1.4/install/controller/ | bash -s - -y\n exec nginx -g 'daemon off;'" > start
+RUN printf "curl -skSL https://\$CTRL_HOST/install/controller-agent | bash -s - -y\n exec nginx -g 'daemon off;'" > start
 
 CMD ["sh", "/controller/start"]
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="NGINX Controller Engineering"
 ARG API_KEY
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 
-# e.g https://<fqdn>:8443/1.4
+# e.g https://<fqdn>/install/controller-agent
 ARG CONTROLLER_URL
 ENV ENV_CONTROLLER_URL=$CONTROLLER_URL
 
@@ -67,7 +67,7 @@ RUN set -ex \
   && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs  \
   && rm -rf /var/lib/apt/lists/* \
   # Install Controller Agent
-  && curl -k -sS -L ${CONTROLLER_URL}/install/controller/ > install.sh \
+  && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -65,11 +65,6 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_url}" -o -n "$
     sh -c "sed -i.old -e 's/instance_name.*$/instance_name = $instance_name/' \
 	${agent_conf_file}"
 
-    test -n "${controller_url}" && \
-    echo " ---> using controller = ${controller_url}" && \
-    sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
-	${agent_conf_file}"
-
     test -n "${location}" && \
     echo " ---> using location = ${location}" && \
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \

--- a/ubuntu/examples/agent-layer/Dockerfile
+++ b/ubuntu/examples/agent-layer/Dockerfile
@@ -21,6 +21,6 @@ WORKDIR /controller
 # Example solution for multiple service management in docker image could be found in official docker
 # documentation:
 # https://docs.docker.com/config/containers/multi-service_container
-RUN printf "curl -skSL https://\$CTRL_HOST:8443/1.4/install/controller/ | bash -s - -y\n exec nginx -g 'daemon off;'" > start
+RUN printf "curl -skSL https://\$CTRL_HOST/install/controller-agent | bash -s - -y\n exec nginx -g 'daemon off;'" > start
 
 CMD ["sh", "/controller/start"]


### PR DESCRIPTION
Agent script url was updated to https://<fqdn>/install/controller-agent as of 3.11. This MR adds support for older version of NGINX Controller.