### PR TITLE
Fix ubuntu NAP entrypoint

### DIFF
--- a/ubuntu/nap/entrypoint.sh
+++ b/ubuntu/nap/entrypoint.sh
@@ -75,11 +75,6 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${location}" ]; then
     sh -c "sed -i.old -e 's/instance_name.*$/instance_name = $instance_name/' \
 	${agent_conf_file}"
 
-    test -n "${controller_url}" && \
-    echo " ---> using controller = ${controller_url}" && \
-    sh -c "sed -i.old -e 's@api_url.*@api_url = $controller_url@' \
-	${agent_conf_file}"
-
     test -n "${location}" && \
     echo " ---> using location = ${location}" && \
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \


### PR DESCRIPTION
Fix ubuntu NAP entrypoint by removing unneded `api_url` replacement in `agent.conf`