### PR TITLE
Add NGINX_PLUS_VERSION to parameterize which NGINX version is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,15 @@ docker run --name mynginx1 -d -e ENV_CONTROLLER_API_URL=https://<fqdn>:8443/1.4 
 ENV_CONTROLLER_API_URL=https://<fqdn>:8443/1.4
 ```
 
+### 4.5 Overriding NGINX Plus version
+
+Version of NGINX Plus installed inside docker image could changed using `NGINX_PLUS_VERSION` build time argument.
+`NGINX_PLUS_VERSION` should be set to release number of NGINX Plus e.g. `23`
+
+```bash
+docker build --build-arg CONTROLLER_URL=https://<fqdn>/install/controller-agent --build-arg API_KEY='abcdefxxxxxx' --build-arg NGINX_PLUS_VERSION=22 -t nginx-agent .
+```
+
 ## 5.0 Support
 
 This project is supported and has been validated with Controller Agent v3.10 and later.

--- a/amazon/no-nap/Dockerfile
+++ b/amazon/no-nap/Dockerfile
@@ -18,6 +18,9 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -53,7 +56,7 @@ RUN set -ex \
   test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
   wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nginx-plus-amazon2.repo \
   # NGINX Javascript module needed for APIM
-  && yum update && yum -y install nginx-plus nginx-plus-module-njs  \
+  && yum update && yum -y install nginx-plus-${NGINX_PLUS_VERSION}* nginx-plus-module-njs-${NGINX_PLUS_VERSION}*  \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \

--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -3,6 +3,9 @@ FROM centos:7 as nginx-installer
 
 LABEL maintainer="NGINX Controller Engineering"
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -29,7 +32,7 @@ RUN set -ex \
   test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
   wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nginx-plus-7.4.repo \
   # NGINX Javascript module needed for APIM
-  && yum update && yum -y install nginx-plus nginx-plus-module-njs
+  && yum update && yum -y install nginx-plus-${NGINX_PLUS_VERSION}* nginx-plus-module-njs-${NGINX_PLUS_VERSION}*
 
 FROM nginx-installer as agent-installer
 # Install Controller Agent

--- a/centos/no-nap/Dockerfile
+++ b/centos/no-nap/Dockerfile
@@ -18,6 +18,9 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -42,7 +45,7 @@ RUN set -ex \
   test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
   wget -P /etc/yum.repos.d https://cs.nginx.com/static/files/nginx-plus-7.4.repo \
   # NGINX Javascript module needed for APIM
-  && yum update && yum -y install nginx-plus nginx-plus-module-njs  \
+  && yum update && yum -y install nginx-plus-${NGINX_PLUS_VERSION}* nginx-plus-module-njs-${NGINX_PLUS_VERSION}*  \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -3,6 +3,9 @@ FROM debian:stretch-slim as nginx-installer
 
 LABEL maintainer="NGINX Controller Engineering"
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -33,7 +36,7 @@ RUN set -ex \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
   && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
   # NGINX Javascript module needed for APIM
-  && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs
+  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*
 
 FROM nginx-installer as agent-installer
 # Install Controller Agent

--- a/debian/no-nap/Dockerfile
+++ b/debian/no-nap/Dockerfile
@@ -18,6 +18,9 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -48,7 +51,7 @@ RUN set -ex \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
   && printf "deb https://plus-pkgs.nginx.com/debian stretch nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
   # NGINX Javascript module needed for APIM
-  && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs  \
+  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*  \
   && rm -rf /var/lib/apt/lists/* \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -6,6 +6,9 @@ FROM ubuntu:18.04 as nginx-installer
 
 LABEL maintainer="NGINX Controller Engineering"
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -49,7 +52,7 @@ RUN set -ex \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
   && printf "deb https://plus-pkgs.nginx.com/ubuntu $(lsb_release -cs) nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
   # NGINX Javascript module needed for APIM
-  && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs
+  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*
 
 FROM nginx-installer as agent-installer
 # Install Controller Agent

--- a/ubuntu/no-nap/Dockerfile
+++ b/ubuntu/no-nap/Dockerfile
@@ -21,6 +21,9 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 
+# NGXIN Plus release e.g 23
+ARG NGINX_PLUS_VERSION=23
+
 # Download certificate (nginx-repo.crt) and key (nginx-repo.key) from the customer portal (https://cs.nginx.com)
 # and copy to the build context
 COPY nginx-repo.* /etc/ssl/nginx/
@@ -64,7 +67,7 @@ RUN set -ex \
   && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
   && printf "deb https://plus-pkgs.nginx.com/ubuntu $(lsb_release -cs) nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
   # NGINX Javascript module needed for APIM
-  && apt-get update && apt-get install -y nginx-plus nginx-plus-module-njs  \
+  && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*  \
   && rm -rf /var/lib/apt/lists/* \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \


### PR DESCRIPTION
Add new parameter `NGINX_PLUS_VERSION` to parametrize which NGINX Plus release version is installed.
For now, this only works for no-nap version of Dockerfiles. 