### PR TITLE
feature: parametrizing nplus version in nap enabled examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Version of NGINX Plus installed inside docker image could changed using `NGINX_P
 docker build --build-arg CONTROLLER_URL=https://<fqdn>/install/controller-agent --build-arg API_KEY='abcdefxxxxxx' --build-arg NGINX_PLUS_VERSION=22 -t nginx-agent .
 ```
 
+For NAP-Enabled NGINX Docker Containers, information about App Security requirements can be found [here](https://docs.nginx.com/nginx-controller/admin-guides/install/try-nginx-controller-app-sec/)
 ## 5.0 Support
 
 This project is supported and has been validated with Controller Agent v3.10 and later.

--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -48,8 +48,17 @@ RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-RUN yum -y install app-protect \
-  && sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
+ARG NGINX_PLUS_VERSION=23
+RUN if [ "$NGINX_PLUS_VERSION" -lt 22 ] ; then \
+	echo "NGINX Plus version ${NGINX_PLUS_VERSION} is not supported by NAP" \
+	&& exit 1 ; \
+	elif [ "$NGINX_PLUS_VERSION" -eq 22 ] ; \
+	then \
+	yum -y install app-protect-22+3.243.1 ; \
+	else \
+	yum -y install app-protect ; \
+	fi
+RUN sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
 
 
 FROM nap-installer as cleaner

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -50,8 +50,21 @@ RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-RUN apt-get install -y app-protect \
-  && sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
+ARG NGINX_PLUS_VERSION=23
+RUN if [ "$NGINX_PLUS_VERSION" -lt 22 ] ; \
+	then \
+	echo "NGINX Plus version ${NGINX_PLUS_VERSION} is not supported by NAP" \
+	&& exit 1 ; \
+	elif [ "$NGINX_PLUS_VERSION" -eq 22 ] ; then \
+	apt-get install -y app-protect-compiler=5.1.0-1~stretch \
+   	app-protect-engine=5.1.0-1~stretch \
+   	app-protect-plugin=3.243.1-1~stretch \
+   	nginx-plus-module-appprotect=22+3.243.1-1~stretch \
+	app-protect=22+3.243.1-1~stretch ; \
+	else \
+	apt-get install -y app-protect ; \
+	fi
+RUN sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
 
 
 FROM nap-installer as cleaner

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -67,8 +67,14 @@ RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-RUN apt-get install -y app-protect \
-  && sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
+ARG NGINX_PLUS_VERSION=23
+RUN if [ "$NGINX_PLUS_VERSION" -lt 23 ] ; then \
+	echo "NGINX Plus version ${NGINX_PLUS_VERSION} is not supported by NAP" \
+	&& exit 1 ; \
+	else \
+	apt-get install -y app-protect ; \
+	fi
+RUN sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/nginx.conf
 
 
 FROM nap-installer as cleaner


### PR DESCRIPTION
Installing specific version of NAP depending on `NGINX_PLUS_VERSION` parameter.
Feature works in Debian and Centos examples.
For Ubuntu, always newest N+ and NAP are installed as older ones don't support Ubuntu OS.
When trying to install N+ version not supported by NAP, error is returned.