### PR TITLE
fix: redirection of logs from log file to main process

### DIFF
--- a/amazon/no-nap/Dockerfile
+++ b/amazon/no-nap/Dockerfile
@@ -69,8 +69,8 @@ RUN set -ex \
   && gpg --batch --delete-keys "$NGINX_GPGKEY"
 
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY entrypoint.sh /
 

--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -85,8 +85,8 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY custom_log_format.json /etc/nginx/
 

--- a/centos/no-nap/Dockerfile
+++ b/centos/no-nap/Dockerfile
@@ -58,8 +58,8 @@ RUN set -ex \
   && gpg --batch --delete-keys "$NGINX_GPGKEY"
 
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY entrypoint.sh /
 

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -93,8 +93,8 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY custom_log_format.json /etc/nginx/
 

--- a/debian/no-nap/Dockerfile
+++ b/debian/no-nap/Dockerfile
@@ -64,8 +64,8 @@ RUN set -ex \
   && apt-key del "$NGINX_GPGKEY"
 
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 EXPOSE 80
 

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -103,8 +103,8 @@ ENV ENV_CONTROLLER_STORE_UUID=$STORE_UUID
 ARG LOCATION
 ENV ENV_CONTROLLER_LOCATION=$LOCATION
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 COPY custom_log_format.json /etc/nginx/
 

--- a/ubuntu/no-nap/Dockerfile
+++ b/ubuntu/no-nap/Dockerfile
@@ -80,8 +80,8 @@ RUN set -ex \
   && apt-key del "$NGINX_GPGKEY"
 
 # Forward request logs to Docker log collector
-RUN ln -sf /dev/stdout /var/log/nginx-controller/agent.log \
-  && ln -sf /dev/stderr /var/log/nginx/error.log
+RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
+  && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
 EXPOSE 80
 


### PR DESCRIPTION
Redirecting logs from files to main container process (PID 1 process) to make logs visible when using `docker logs` command.