### PR TITLE
refactor: preparations for running under non-root user

### DIFF
--- a/amazon/no-nap/Dockerfile
+++ b/amazon/no-nap/Dockerfile
@@ -72,6 +72,16 @@ RUN set -ex \
 RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
   && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 COPY entrypoint.sh /
 
 EXPOSE 80

--- a/amazon/no-nap/entrypoint.sh
+++ b/amazon/no-nap/entrypoint.sh
@@ -97,12 +97,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -90,6 +90,16 @@ RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
 
 COPY custom_log_format.json /etc/nginx/
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/centos/nap/entrypoint.sh
+++ b/centos/nap/entrypoint.sh
@@ -109,12 +109,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/centos/no-nap/Dockerfile
+++ b/centos/no-nap/Dockerfile
@@ -61,6 +61,16 @@ RUN set -ex \
 RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
   && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 COPY entrypoint.sh /
 
 EXPOSE 80

--- a/centos/no-nap/entrypoint.sh
+++ b/centos/no-nap/entrypoint.sh
@@ -97,12 +97,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -98,6 +98,16 @@ RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
 
 COPY custom_log_format.json /etc/nginx/
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/debian/no-nap/Dockerfile
+++ b/debian/no-nap/Dockerfile
@@ -67,6 +67,16 @@ RUN set -ex \
 RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
   && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/debian/no-nap/entrypoint.sh
+++ b/debian/no-nap/entrypoint.sh
@@ -16,7 +16,7 @@ handle_term()
 {
     echo "received TERM signal"
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -86,7 +86,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -95,12 +97,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -108,6 +108,16 @@ RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
 
 COPY custom_log_format.json /etc/nginx/
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/ubuntu/no-nap/Dockerfile
+++ b/ubuntu/no-nap/Dockerfile
@@ -83,6 +83,16 @@ RUN set -ex \
 RUN ln -sf /proc/1/fd/1 /var/log/nginx-controller/agent.log \
   && ln -sf /proc/1/fd/2 /var/log/nginx/error.log
 
+# Update ownership for the necessary filesystem objects for running under "nginx" user
+RUN chown -R nginx:nginx /var/run/ \
+  && chown -R nginx:nginx /var/log/nginx/ \
+  && chown -R nginx:nginx /var/log/nginx-controller/ \
+  && chown -R nginx:nginx /var/cache/nginx/ \
+  && chown -R nginx:nginx /etc/controller-agent/ \
+  && chown -R nginx:nginx /etc/nginx/
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGTERM

--- a/ubuntu/no-nap/entrypoint.sh
+++ b/ubuntu/no-nap/entrypoint.sh
@@ -16,7 +16,7 @@ handle_term()
 {
     echo "received TERM signal"
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -86,7 +86,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -95,12 +97,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."


### PR DESCRIPTION

- Remove the use of the `service` command in some `entrypoint.sh` scripts

- Switch the user in all docker files, set ownership

- Fix `wait_term()` in all `entrypoint.sh` files to wait for the `controller-agent` process and do the cleanup
