### PR TITLE
fixed the script to put security true only when its needed

### DIFF
--- a/centos/nap/entrypoint.sh
+++ b/centos/nap/entrypoint.sh
@@ -80,8 +80,10 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_api_url}" -o -
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \
 	${agent_conf_file}"
 
+    if ! grep -Fq "security = " ${agent_conf_file}; then
     sh -c "sed -i.old -e 's/\[extensions\]/&\nsecurity = True/g' \
-	${agent_conf_file}"
+    ${agent_conf_file}"
+    fi
 
     test -f "${agent_conf_file}" && \
     chmod 644 ${agent_conf_file} && \

--- a/centos/nap/entrypoint.sh
+++ b/centos/nap/entrypoint.sh
@@ -82,7 +82,7 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_api_url}" -o -
 
     if ! grep -Fq "security = " ${agent_conf_file}; then
     sh -c "sed -i.old -e 's/\[extensions\]/&\nsecurity = True/g' \
-    ${agent_conf_file}"
+        ${agent_conf_file}"
     fi
 
     test -f "${agent_conf_file}" && \

--- a/debian/nap/entrypoint.sh
+++ b/debian/nap/entrypoint.sh
@@ -81,8 +81,10 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_api_url}" -o -
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \
 	${agent_conf_file}"
 
+    if ! grep -Fq "security = " ${agent_conf_file}; then
     sh -c "sed -i.old -e 's/\[extensions\]/&\nsecurity = True/g' \
 	${agent_conf_file}"
+    fi
 
     test -f "${agent_conf_file}" && \
     chmod 644 ${agent_conf_file} && \

--- a/ubuntu/nap/entrypoint.sh
+++ b/ubuntu/nap/entrypoint.sh
@@ -81,8 +81,10 @@ if [ -n "${api_key}" -o -n "${instance_name}" -o -n "${controller_api_url}" -o -
     sh -c "sed -i.old -e 's/location_name.*$/location_name = $location/' \
 	${agent_conf_file}"
 
+    if ! grep -Fq "security = " ${agent_conf_file}; then
     sh -c "sed -i.old -e 's/\[extensions\]/&\nsecurity = True/g' \
 	${agent_conf_file}"
+    fi
 
     test -f "${agent_conf_file}" && \
     chmod 644 ${agent_conf_file} && \


### PR DESCRIPTION
fixed the script to put security true only when its not available in the agent.conf for nap containers