### PR TITLE
refactor: wait for nginx workers before running agent

### DIFF
--- a/amazon/no-nap/entrypoint.sh
+++ b/amazon/no-nap/entrypoint.sh
@@ -29,6 +29,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/centos/nap/entrypoint.sh
+++ b/centos/nap/entrypoint.sh
@@ -38,6 +38,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/centos/no-nap/entrypoint.sh
+++ b/centos/no-nap/entrypoint.sh
@@ -29,6 +29,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/debian/nap/entrypoint.sh
+++ b/debian/nap/entrypoint.sh
@@ -39,6 +39,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/debian/no-nap/entrypoint.sh
+++ b/debian/no-nap/entrypoint.sh
@@ -29,6 +29,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/ubuntu/nap/entrypoint.sh
+++ b/ubuntu/nap/entrypoint.sh
@@ -39,6 +39,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 

--- a/ubuntu/no-nap/entrypoint.sh
+++ b/ubuntu/no-nap/entrypoint.sh
@@ -29,6 +29,16 @@ nginx -g "daemon off;" &
 
 nginx_pid=$!
 
+wait_workers()
+{
+    while ! pgrep -f 'nginx: worker process' >/dev/null 2>&1; do
+        echo "waiting for nginx workers ..."
+        sleep 2
+    done
+}
+
+wait_workers
+
 test -n "${ENV_CONTROLLER_API_KEY}" && \
     api_key=${ENV_CONTROLLER_API_KEY}
 


### PR DESCRIPTION
Sometimes it takes longer for `nginx` to launch workers, especially with enabled NAP. `nginx` should be up and fully running by the moment we run the `controller-agent`. Otherwise, the agent can't do the proper setup. 

Fixes: https://github.com/nginxinc/docker-nginx-controller/issues/47

- now `entrypoint.sh` is waiting for nginx workers to appear in the `pgrep` output before running the agent 

here is the example log output (full nginx startup with NAP took ~10 seconds):
```
starting nginx ...
waiting for nginx workers ...
2021/02/26 06:34:58 [notice] 17#17: APP_PROTECT { "event": "configuration_load_start", "configSetFile": "/opt/app_protect/config/config_set.json" }
waiting for nginx workers ...
waiting for nginx workers ...
waiting for nginx workers ...
waiting for nginx workers ...
2021/02/26 06:34:58 [notice] 17#17: APP_PROTECT policy 'app_protect_default_policy' from: /etc/nginx/NginxDefaultPolicy.json compiled successfully
2021/02/26 06:34:58 [notice] 17#17: APP_PROTECT { "event": "configuration_load_success", "software_version": "3.332.0", "user_signatures_packages":[],"attack_signatures_package":{"revision_datetime":"2019-07-16T12:21:31Z"},"completed_successfully":true,"threat_campaigns_package":{}}
2021/02/26 06:34:58 [notice] 17#17: using the "epoll" event method
2021/02/26 06:34:58 [notice] 17#17: nginx/1.19.5 (nginx-plus-r23)
2021/02/26 06:34:58 [notice] 17#17: built by gcc 4.8.5 20150623 (Red Hat 4.8.5-39) (GCC)
2021/02/26 06:34:58 [notice] 17#17: OS: Linux 4.19.121-linuxkit
2021/02/26 06:34:58 [notice] 17#17: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2021/02/26 06:34:58 [notice] 17#17: start worker processes
2021/02/26 06:34:58 [notice] 17#17: start worker process 46
2021/02/26 06:34:58 [notice] 17#17: start worker process 47
2021/02/26 06:34:58 [notice] 17#17: start worker process 48
2021/02/26 06:34:58 [notice] 17#17: start worker process 50
2021/02/26 06:35:08 [notice] 46#46: APP_PROTECT { "event": "waf_connected", "enforcer_thread_id": 0, "worker_pid": 46, "mode": "operational", "mode_changed": false}
2021/02/26 06:35:08 [notice] 50#50: APP_PROTECT { "event": "waf_connected", "enforcer_thread_id": 2, "worker_pid": 50, "mode": "operational", "mode_changed": false}
2021/02/26 06:35:08 [notice] 47#47: APP_PROTECT { "event": "waf_connected", "enforcer_thread_id": 1, "worker_pid": 47, "mode": "operational", "mode_changed": false}
2021/02/26 06:35:08 [notice] 48#48: APP_PROTECT { "event": "waf_connected", "enforcer_thread_id": 3, "worker_pid": 48, "mode": "operational", "mode_changed": false}
updating /etc/controller-agent/agent.conf ...
 ---> using api_key = 3b5d0a966f26148229bdf1864ee42816
 ---> using instance_name = 5f46dc6cf19a
starting controller-agent ...
time="Feb 26 2021 06:35:09.043" level="info" msg="Starting Nginx Controller (Go) Agent. Version: 3.15.17..." feature="main"
```