### PR TITLE
refactor: wait for the agent process instead of nginx

### DIFF
--- a/amazon/no-nap/entrypoint.sh
+++ b/amazon/no-nap/entrypoint.sh
@@ -107,12 +107,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/centos/nap/entrypoint.sh
+++ b/centos/nap/entrypoint.sh
@@ -121,12 +121,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/centos/no-nap/entrypoint.sh
+++ b/centos/no-nap/entrypoint.sh
@@ -107,12 +107,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/debian/nap/entrypoint.sh
+++ b/debian/nap/entrypoint.sh
@@ -21,7 +21,7 @@ handle_term()
     echo "stopping bd-agent"
     kill -TERM "${bd_agent_pid}" 2>/dev/null
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -111,7 +111,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -120,12 +122,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/debian/no-nap/entrypoint.sh
+++ b/debian/no-nap/entrypoint.sh
@@ -16,7 +16,7 @@ handle_term()
 {
     echo "received TERM signal"
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -96,7 +96,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -105,12 +107,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/ubuntu/nap/entrypoint.sh
+++ b/ubuntu/nap/entrypoint.sh
@@ -21,7 +21,7 @@ handle_term()
     echo "stopping bd-agent"
     kill -TERM "${bd_agent_pid}" 2>/dev/null
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -111,7 +111,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -120,12 +122,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."

--- a/ubuntu/no-nap/entrypoint.sh
+++ b/ubuntu/no-nap/entrypoint.sh
@@ -16,7 +16,7 @@ handle_term()
 {
     echo "received TERM signal"
     echo "stopping controller-agent ..."
-    service controller-agent stop
+    kill -TERM "${agent_pid}" 2>/dev/null
     echo "stopping nginx ..."
     kill -TERM "${nginx_pid}" 2>/dev/null
 }
@@ -96,7 +96,9 @@ if ! grep '^api_key.*=[ ]*[[:alnum:]].*' ${agent_conf_file} > /dev/null 2>&1; th
 fi
 
 echo "starting controller-agent ..."
-service controller-agent start > /dev/null 2>&1 < /dev/null
+/usr/bin/nginx-controller-agent > /dev/null 2>&1 < /dev/null &
+
+agent_pid=$!
 
 if [ $? != 0 ]; then
     echo "couldn't start the agent, please check ${agent_log_file}"
@@ -105,12 +107,13 @@ fi
 
 wait_term()
 {
-    wait ${nginx_pid}
+    wait ${agent_pid}
     trap - TERM
-    echo "wait for nginx to stop..."
+    kill -QUIT "${nginx_pid}" 2>/dev/null
+    echo "waiting for nginx to stop..."
     wait ${nginx_pid}
 }
 
 wait_term
 
-echo "nginx master process has stopped, exiting."
+echo "controller-agent process has stopped, exiting."


### PR DESCRIPTION
- wait for the `agent` process instead of `nginx` in `entrypoint.sh`
- shutdown `nginx` gracefully if `agent` exits
