### PR TITLE
Do not start the agent after install

### DIFF
--- a/amazon/no-nap/Dockerfile
+++ b/amazon/no-nap/Dockerfile
@@ -64,8 +64,7 @@ RUN set -ex \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
-  # TODO: remove once launching agent using `service` has been handled in the install script
-  && sed -i '/^# Unconditionally stop the agent service/,$d' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data
   && rm /etc/ssl/nginx/nginx-repo.* \

--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -42,8 +42,7 @@ ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
 RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
-  # TODO: remove once launching agent using `service` has been handled in the install script
-  && sed -i '/^# Unconditionally stop the agent service/,$d' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
 
 FROM agent-installer as nap-installer

--- a/centos/no-nap/Dockerfile
+++ b/centos/no-nap/Dockerfile
@@ -53,8 +53,7 @@ RUN set -ex \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
-  # TODO: remove once launching agent using `service` has been handled in the install script
-  && sed -i '/^# Unconditionally stop the agent service/,$d' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data
   && rm /etc/ssl/nginx/nginx-repo.* \

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -46,6 +46,7 @@ ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
 RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
 
 FROM agent-installer as nap-installer

--- a/debian/no-nap/Dockerfile
+++ b/debian/no-nap/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data
   && rm /etc/ssl/nginx/nginx-repo.* \

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -62,6 +62,7 @@ ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
 RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
 
 

--- a/ubuntu/no-nap/Dockerfile
+++ b/ubuntu/no-nap/Dockerfile
@@ -76,6 +76,7 @@ RUN set -ex \
   # Install Controller Agent
   && curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
+  && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y \
   # cleanup sensitive nginx-plus data
   && rm /etc/ssl/nginx/nginx-repo.* \


### PR DESCRIPTION
The image build process has an issue related to the systemd on Ubuntu 16.04. 
The simplest way to resolve that is to avoid starting the Agent (using systemd) after install, there is no point to do that during the image build. Also, `entrypoint.sh` is not using `systemd` to run the Agent.

https://nginxsoftware.atlassian.net/browse/IND-24099