### PR TITLE
fix: remove python from agent install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,7 @@ FROM nginx-plus
 # Install everything needed to install the Controller Agent so that the container can start quickly
 RUN apt-get update &&\
         apt install -y \
-        curl python gnupg2 procps dh-python distro-info-data libmpdec2 \
-        libpython3-stdlib libpython3.5-minimal libpython3.5-stdlib \
-        lsb-release python3 python3-minimal python3.5 python3.5-minimal \
-        sudo
+        curl procps sudo 
 
 EXPOSE 80 443 8080
 STOPSIGNAL SIGTERM


### PR DESCRIPTION
IND-26376
As per slack conversation, agent install does not require python any more. Trimming down the required packages list.