### PR TITLE
IND-29317 | Support for nap docker-agent with new N+ repo

### DIFF
--- a/centos/nap/Dockerfile
+++ b/centos/nap/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:7 as nginx-installer
 
 LABEL maintainer="NGINX Controller Engineering"
 
-# NGXIN Plus release e.g 24
-ARG NGINX_PLUS_VERSION=24
+# NGXIN Plus release e.g 25
+ARG NGINX_PLUS_VERSION=25
 
 COPY nginx-plus-api.conf /etc/nginx/conf.d/
 COPY entrypoint.sh /
@@ -41,14 +41,16 @@ ARG CONTROLLER_URL
 ARG API_KEY
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
-RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
+RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
+    --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
+  curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-ARG NGINX_PLUS_VERSION=24
+ARG NGINX_PLUS_VERSION=25
 RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
     --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
   if [ "$NGINX_PLUS_VERSION" -lt 22 ] ; then \

--- a/debian/nap/Dockerfile
+++ b/debian/nap/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster-slim as nginx-installer
 LABEL maintainer="NGINX Controller Engineering"
 
 # NGXIN Plus release e.g 24
-ARG NGINX_PLUS_VERSION=24
+ARG NGINX_PLUS_VERSION=25
 
 COPY nginx-plus-api.conf /etc/nginx/conf.d/
 COPY entrypoint.sh /
@@ -30,11 +30,12 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644
     apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
   done; \
   test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
-  echo "Acquire::https::plus-pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
-  && printf "deb https://plus-pkgs.nginx.com/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+  echo "Acquire::https::pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && printf "deb https://pkgs.nginx.com/plus/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+  && printf "deb https://pkgs.nginx.com/app-protect/debian buster nginx-plus\n" > /etc/apt/sources.list.d/nginx-app-protect.list \
   # NGINX Javascript module needed for APIM
   && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*
 
@@ -44,14 +45,16 @@ ARG CONTROLLER_URL
 ARG API_KEY
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
-RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
+RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
+    --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
+  curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-ARG NGINX_PLUS_VERSION=24
+ARG NGINX_PLUS_VERSION=25
 RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
   --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
   if [ "$NGINX_PLUS_VERSION" -lt 22 ] ; \
@@ -73,7 +76,7 @@ RUN sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/
 FROM nap-installer as cleaner
 # cleanup sensitive nginx-plus data
 RUN rm /etc/apt/sources.list.d/nginx-plus.list \
-  && rm /etc/apt/apt.conf.d/90nginx \
+  && rm /etc/apt/apt.conf.d/90pkgs-nginx \
   && apt-key del $NGINX_GPGKEY \
   && rm -rf /var/lib/apt/lists/*
 

--- a/ubuntu/nap/Dockerfile
+++ b/ubuntu/nap/Dockerfile
@@ -6,8 +6,8 @@ FROM ubuntu:18.04 as nginx-installer
 
 LABEL maintainer="NGINX Controller Engineering"
 
-# NGXIN Plus release e.g 24
-ARG NGINX_PLUS_VERSION=24
+# NGXIN Plus release e.g 25
+ARG NGINX_PLUS_VERSION=25
 
 COPY nginx-plus-api.conf /etc/nginx/conf.d/
 COPY entrypoint.sh /
@@ -46,11 +46,12 @@ RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644
     apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
   done; \
   test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
-  echo "Acquire::https::plus-pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx \
-  && echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx \
-  && printf "deb https://plus-pkgs.nginx.com/ubuntu $(lsb_release -cs) nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+  echo "Acquire::https::pkgs.nginx.com::Verify-Peer \"true\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && echo "Acquire::https::pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90pkgs-nginx \
+  && printf "deb https://pkgs.nginx.com/plus/ubuntu $(lsb_release -cs) nginx-plus\n" > /etc/apt/sources.list.d/nginx-plus.list \
+  && printf "deb https://pkgs.nginx.com/app-protect/ubuntu $(lsb_release -cs) nginx-plus\n" > /etc/apt/sources.list.d/nginx-app-protect.list \
   # NGINX Javascript module needed for APIM
   && apt-get update && apt-get install -y nginx-plus=${NGINX_PLUS_VERSION}* nginx-plus-module-njs=${NGINX_PLUS_VERSION}*
 
@@ -60,7 +61,9 @@ ARG CONTROLLER_URL
 ARG API_KEY
 ENV ENV_CONTROLLER_API_KEY=$API_KEY
 ARG STORE_UUID
-RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
+RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
+    --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
+  curl -k -sS -L ${CONTROLLER_URL} > install.sh \
   && sed -i 's/^assume_yes=""/assume_yes="-y"/' install.sh \
   && sed -i 's,-n "${NGINX_GPGKEY}",true,' install.sh \
   && sh ./install.sh -y
@@ -68,7 +71,7 @@ RUN curl -k -sS -L ${CONTROLLER_URL} > install.sh \
 
 FROM agent-installer as nap-installer
 # Install nginx-app-protect
-ARG NGINX_PLUS_VERSION=24
+ARG NGINX_PLUS_VERSION=25
 RUN --mount=type=secret,id=nginx-crt,dst=/etc/ssl/nginx/nginx-repo.crt,mode=0644 \
   --mount=type=secret,id=nginx-key,dst=/etc/ssl/nginx/nginx-repo.key,mode=0644 \
   if [ "$NGINX_PLUS_VERSION" -lt 23 ] ; then \
@@ -83,7 +86,7 @@ RUN sed -i "6 a load_module modules/ngx_http_app_protect_module.so;" /etc/nginx/
 FROM nap-installer as cleaner
 # cleanup sensitive nginx-plus data
 RUN rm /etc/apt/sources.list.d/nginx-plus.list \
-  && rm /etc/apt/apt.conf.d/90nginx \
+  && rm /etc/apt/apt.conf.d/90pkgs-nginx \
   && apt-key del $NGINX_GPGKEY \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The old repo for N+ is deprecated and will soon be retired hence this change brings support for new repo moving forward.
`How do I know which repo I’m using?

The simplest method is to check the hostname used in the package manager configuration:

· The old repo hostname is plus-pkgs.nginx.com

· The new repo hostname is pkgs.nginx.com